### PR TITLE
Add Link Time Optimization (LTO) option

### DIFF
--- a/.ci/arduino.groovy
+++ b/.ci/arduino.groovy
@@ -39,7 +39,7 @@ def parseWarnings(String key) {
 }
 
 def buildMySensorsMicro(config, sketches, String key) {
-	def fqbn = '-fqbn MySensors:avr:MysensorsMicro -prefs build.f_cpu=1000000 -prefs build.mcu=atmega328p'
+	def fqbn = '-fqbn MySensors:avr:MysensorsMicro -prefs build.f_cpu=1000000 -prefs build.mcu=atmega328p -prefs compiler.ar.cmd=avr-ar'
 	config.pr.setBuildStatus(config, 'PENDING', 'Toll gate (MySensorsMicro - '+key+')', 'Building...', '${BUILD_URL}flowGraphTable/')
 	try {
 		for (sketch = 0; sketch < sketches.size(); sketch++) {

--- a/boards.txt
+++ b/boards.txt
@@ -1,4 +1,5 @@
 menu.cpu=Processor
+menu.LTO=Compiler LTO
 
 ######################################
 ## Sensebender Micro
@@ -30,3 +31,16 @@ MysensorsMicro.menu.cpu.8Mhz.build.f_cpu=8000000L
 
 MysensorsMicro.menu.cpu.1Mhz=Atmega328 1Mhz
 MysensorsMicro.menu.cpu.1Mhz.build.f_cpu=1000000L
+
+# Compiler link time optimization
+MysensorsMicro.menu.LTO.Os=Disabled (default)
+MysensorsMicro.menu.LTO.Os.compiler.c.extra_flags=
+MysensorsMicro.menu.LTO.Os.compiler.c.elf.extra_flags=
+MysensorsMicro.menu.LTO.Os.compiler.cpp.extra_flags=
+MysensorsMicro.menu.LTO.Os.ltoarcmd=avr-ar
+
+MysensorsMicro.menu.LTO.Os_flto=Enabled
+MysensorsMicro.menu.LTO.Os_flto.compiler.c.extra_flags=-Wextra -flto
+MysensorsMicro.menu.LTO.Os_flto.compiler.c.elf.extra_flags=-w -flto
+MysensorsMicro.menu.LTO.Os_flto.compiler.cpp.extra_flags=-Wextra -flto
+MysensorsMicro.menu.LTO.Os_flto.ltoarcmd=avr-gcc-ar

--- a/platform.txt
+++ b/platform.txt
@@ -28,7 +28,7 @@ compiler.c.elf.cmd=avr-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp
 compiler.cpp.cmd=avr-g++
 compiler.cpp.flags=-c -g -Os {compiler.warning_flags} -std=gnu++11 -fno-exceptions -ffunction-sections -fdata-sections -fno-threadsafe-statics -MMD
-compiler.ar.cmd=avr-ar
+compiler.ar.cmd={ltoarcmd}
 compiler.ar.flags=rcs
 compiler.objcopy.cmd=avr-objcopy
 compiler.objcopy.eep.flags=-O ihex -j .eeprom --set-section-flags=.eeprom=alloc,load --no-change-warnings --change-section-lma .eeprom=0


### PR DESCRIPTION
Link Time Optimization (LTO) is very useful option especially on large libraries like mysensors. For example my LCD node sketch stats withoit LTO:
```
Sketch uses 30528 bytes (99%) of program storage space. Maximum is 30720 bytes.
Global variables use 1191 bytes (58%) of dynamic memory, leaving 857 bytes for local variables. Maximum is 2048 bytes.

```
with LTO enabled:
```
Sketch uses 27024 bytes (87%) of program storage space. Maximum is 30720 bytes.
Global variables use 1212 bytes (59%) of dynamic memory, leaving 836 bytes for local variables. Maximum is 2048 bytes.

```
Unfortunately SenseBender lacks that feature. That push request could fix that.